### PR TITLE
perf(RedirectService): import only needed symbols from rxjs

### DIFF
--- a/src/app/redirect/redirect.service.ts
+++ b/src/app/redirect/redirect.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { Http, Response, Headers, RequestOptions } from '@angular/http';
-import { Observable } from 'rxjs/Rx';
+import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/operator/map';
 
 import { Redirect } from './redirect.model';


### PR DESCRIPTION
Importing from rxjs/Rx causes nearly all Rx operators to be imported,
even those that aren’t being used. By importing from rxjs/Observable,
the size of RxJS in the minified bundle decreased from 186 to 44.